### PR TITLE
Improved Requires and BuildRequires parsing

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -198,7 +198,7 @@ class Requirement:
             self.operator = match.group(2)
             self.version = match.group(3)
         else:
-            self.name = None
+            self.name = name
             self.operator = None
             self.version = None
 

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -28,7 +28,7 @@ class TestSpecFileParser:
         assert '1.16' == spec.version
         assert 'noarch' == spec.buildarch
         assert 2 == len(spec.build_requires)
-        assert 'perl >= 1:5.6.0' == spec.build_requires[0]
+        assert 'perl >= 1:5.6.0' == spec.build_requires[0].line
 
     def test_parse_llvm_spec(self):
         spec = Spec.from_file(os.path.join(CURRENT_DIR, 'llvm.spec'))


### PR DESCRIPTION
Added the Requirement class to handle Requires and BuildRequires lines
with additional version number specifications. This is intended to
improve upon the current situation where the entire string is a part of
the returned string.

The new class' `name` attribute contains the name of the package which is
the target of the Requires or BuildRequires clause.