### PR TITLE
add list tags to packages

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -251,6 +251,10 @@ class Package:
     def __init__(self, name):
         assert isinstance(name, str)
 
+        for tag in _tags:
+            if tag.attr_type is list:
+                setattr(self, tag.name, tag.attr_type())
+
         self.name = name
         self.is_subpackage = False
 


### PR DESCRIPTION
Hello,

I want to parse my **spec** file and to list **all** _packages_ required for installation.

I have found that `spec.build_requires` returns **only** the requirements for _main_ package.

However, I need to list all requirements for all packages creation.

This `PR` add this ability

~~~python
print(spec.build_requires)
for package in spec.packages:
    print(package.build_requires)
~~~

Regards,