### PR TITLE
Add parsing of %include tags and of Requires(post) tags.

### DIFF
--- a/tests/include-test.inc
+++ b/tests/include-test.inc
@@ -1,0 +1,7 @@
+#
+# This .inc file is here just to test if the tool is able to correctly include
+# included files
+#
+
+%attr(-, root, root) /usr/local/a-dummy-file
+

--- a/tests/include-test.spec
+++ b/tests/include-test.spec
@@ -1,0 +1,24 @@
+# Example SPEC
+
+Name: pkgA
+Summary: Example package
+Group: Applications/Internet
+Version: 1.0.0
+Release: 1
+License: GPL
+Vendor: None
+
+Requires: systemPkgA, pkgB
+
+%description
+Metapackage for example purposes
+
+%install
+%clean
+%pre
+%post
+%posttrans
+%preun
+%postun
+%files
+%include include-test.inc

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -136,6 +136,14 @@ class TestSpecFileParser:
         core_package = spec.packages_dict['git-core']
         assert len(core_package.build_requires) == 0
 
+    def test_include_tag(self):
+        """Make sure that %include is hanlded correctly
+
+        """
+        spec = Spec.from_file(os.path.join(CURRENT_DIR, 'include-test.spec'))
+
+        core_package = spec.packages_dict['pkgA']
+        assert len(core_package.build_requires) == 0
 
 class TestSpecClass:
 
@@ -188,7 +196,7 @@ class TestReplaceMacro:
 Name:           foo
 Version:        2
 %define var   bar
-""")
+""", "")
         s = '%{name}/%{version}/%{var}'
         assert 'foo/2/bar' == replace_macros(s, spec)
 
@@ -204,7 +212,7 @@ Version:        2
 Name:           git
 Version:        2.15.1
 %define rcrev   .rc0
-        """)
+        """, "")
 
         assert 'https://www.kernel.org/pub/software/scm/git/testing/git-2.15.1.rc0.tar.xz' \
                == replace_macros(
@@ -214,7 +222,7 @@ Version:        2.15.1
         spec = Spec.from_string("""
 Name:           git
 Version:        2.15.1
-        """)
+        """, "")
 
         assert 'https://www.kernel.org/pub/software/scm/git/testing/git-2.15.1.tar.xz' \
                == replace_macros(


### PR DESCRIPTION
Hi,
I have found your project very interesting and I used it as a base for my own: 
  https://github.com/f18m/rpm-spec-dependency-analyzer

Currently I did hack your spec.py parser and included it in my project but I would like instead to have your lib as a dependency and thus I would like to contribute back my extensions:
 - ability to parse %include tags: I achieved that adding a sort of "pre-processing" step which looks for a regex catching %include tags. Then parsing is done as usual.
 - ability to parse Requires(post). I should add also Requires(pre) btw.
 - ability to parse the files section of the spec.

What do you think?
Please note I'm far from being a Python fluent writer... so I'm sure several things could be written somewhat better.
