### PR TITLE
Fix up Requires handling to make it more predictable

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -404,4 +404,12 @@ def replace_macros(string, spec=None):
                 return str(value)
         return match.string[match.start():match.end()]
 
-    return re.sub(_macro_pattern, _macro_repl, string)
+    # Recursively expand macros
+    # Note: If macros are not defined in the spec file, this won't try to
+    # expand them.
+    while True:
+        ret = re.sub(_macro_pattern, _macro_repl, string)
+        if ret != string:
+            string = ret
+            continue
+        return ret


### PR DESCRIPTION
- Treat Requires/BuildRequires/Obsoletes/Provides/Conflicts the same way
- Split each requirement (etc.) in to its own entry in its respective table (instead of by line)
- Expand macros recursively