### PR TITLE
Add support for %description and %changelog, other multi-line should be easy to add

### DIFF
--- a/examples/d.py
+++ b/examples/d.py
@@ -1,7 +1,7 @@
 from pyrpm.spec import Spec
 
 spec = Spec.from_file("llvm.spec")
-print(spec.version)  # 3.8.0
+print(spec.name)
 print(spec.description)
 
 for package in spec.packages:
@@ -9,4 +9,42 @@ for package in spec.packages:
     print(package.description)
     print()
 
+print(spec.changelog)
 
+
+# llvm
+# LLVM is a compiler infrastructure designed for compile-time, link-time,
+# runtime, and idle-time optimization of programs from arbitrary programming
+# languages. The compiler infrastructure includes mirror sets of programming
+# tools as well as libraries with equivalent functionality.
+#
+#
+# llvm: The Low Level Virtual Machine
+# None
+#
+# llvm-devel: Libraries and header files for LLVM
+# This package contains library and header files needed to develop new native
+# programs that use the LLVM infrastructure.
+#
+#
+#
+# llvm-doc: Documentation for LLVM
+# Documentation for the LLVM compiler infrastructure.
+#
+#
+#
+# llvm-libs: LLVM shared libraries
+# Shared libraries for the LLVM compiler infrastructure.
+#
+#
+#
+# llvm-static: LLVM static libraries
+# Static libraries for the LLVM compiler infrastructure.
+#
+#
+#
+# * Thu Mar 10 2016 Dave Airlie <airlied@redhat.com> 3.8.0-1
+# - llvm 3.8.0 release
+# ...
+# * Tue Oct 06 2015 Jan Vcelak <jvcelak@fedoraproject.org> 3.7.0-100
+# - initial version using cmake build system

--- a/examples/d.py
+++ b/examples/d.py
@@ -1,0 +1,12 @@
+from pyrpm.spec import Spec
+
+spec = Spec.from_file("llvm.spec")
+print(spec.version)  # 3.8.0
+print(spec.description)
+
+for package in spec.packages:
+    print(f'{package.name}: {package.summary if hasattr(package, "summary") else spec.summary}')
+    print(package.description)
+    print()
+
+


### PR DESCRIPTION
I used the `context["multiline"]` to record that we entered a `%description` or `%changelog`.
Then the non-matching lines are added to the target object.
If a line is matching, I remove the `context["multiline"]`

It could be extended to others multi-line fields.

It could be improved by removing the last newline. But I want to start simple, given that I am not familiar with Python.