### PR TITLE
parse ExcludeArch, ExclusiveArch tags with _SplitValue method

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -210,6 +210,24 @@ class _ListAndDict(_Tag):
         return spec_obj, context
 
 
+class _SplitValue(_NameValue):
+    """Parse a (name->value) tag, and at the same time split the tag to a list."""
+
+    def __init__(self, name: str, pattern_obj: re.Pattern, sep: str = None) -> None:
+        super().__init__(name, pattern_obj)
+        self.name_list = '%s_list' % name
+        self.sep = sep
+
+    def update_impl(self, spec_obj: "Spec", context: Dict[str, Any], match_obj: re.Match, line: str) -> Tuple["Spec", dict]:
+        super().update_impl(spec_obj, context, match_obj, line)
+
+        target_obj = _Tag.current_target(spec_obj, context)
+        value = getattr(target_obj, self.name)
+        value = value.split(self.sep)
+        setattr(target_obj, self.name_list, value)
+
+        return spec_obj, context
+
 def re_tag_compile(tag):
     return re.compile(tag, re.IGNORECASE)
 
@@ -238,9 +256,9 @@ _tags = [
     _NameValue("group", re_tag_compile(r"^Group\s*:\s*(.+)")),
     _NameValue("url", re_tag_compile(r"^URL\s*:\s*(\S+)")),
     _NameValue("buildroot", re_tag_compile(r"^BuildRoot\s*:\s*(\S+)")),
-    _NameValue("buildarch", re_tag_compile(r"^BuildArch\s*:\s*(\S+)")),
-    _NameValue("excludearch", re_tag_compile(r"^ExcludeArch\s*:\s*(.+)")),
-    _NameValue("exclusivearch", re_tag_compile(r"^ExclusiveArch\s*:\s*(.+)")),
+    _SplitValue("buildarch", re_tag_compile(r"^BuildArch\s*:\s*(\S+)")),
+    _SplitValue("excludearch", re_tag_compile(r"^ExcludeArch\s*:\s*(.+)")),
+    _SplitValue("exclusivearch", re_tag_compile(r"^ExclusiveArch\s*:\s*(.+)")),
     _ListAndDict("sources", re_tag_compile(r"^(Source\d*\s*):\s*(.+)")),
     _ListAndDict("patches", re_tag_compile(r"^(Patch\d*\s*):\s*(\S+)")),
     _List("build_requires", re_tag_compile(r"^BuildRequires\s*:\s*(.+)")),

--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -239,6 +239,8 @@ _tags = [
     _NameValue("url", re_tag_compile(r"^URL\s*:\s*(\S+)")),
     _NameValue("buildroot", re_tag_compile(r"^BuildRoot\s*:\s*(\S+)")),
     _NameValue("buildarch", re_tag_compile(r"^BuildArch\s*:\s*(\S+)")),
+    _NameValue("excludearch", re_tag_compile(r"^ExcludeArch\s*:\s*(.+)")),
+    _NameValue("exclusivearch", re_tag_compile(r"^ExclusiveArch\s*:\s*(.+)")),
     _ListAndDict("sources", re_tag_compile(r"^(Source\d*\s*):\s*(.+)")),
     _ListAndDict("patches", re_tag_compile(r"^(Patch\d*\s*):\s*(\S+)")),
     _List("build_requires", re_tag_compile(r"^BuildRequires\s*:\s*(.+)")),

--- a/tests/perl-Array-Compare.spec
+++ b/tests/perl-Array-Compare.spec
@@ -9,6 +9,8 @@ URL:            http://search.cpan.org/dist/Array-Compare/
 Source0:        http://www.cpan.org/authors/id/D/DA/DAVECROSS/Array-Compare-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
+ExcludeArch:    alpha
+ExclusiveArch:  i386 x86_64
 BuildRequires:  perl >= 1:5.6.0
 BuildRequires:  perl(Module::Build)
 Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -31,9 +31,12 @@ class TestSpecFileParser:
         assert spec.epoch == "1"
 
         assert spec.version == "1.16"
-        assert spec.buildarch == "noarch"
         assert len(spec.build_requires) == 2
         assert spec.build_requires[0].line == "perl >= 1:5.6.0"
+
+        assert spec.buildarch == "noarch"
+        assert spec.excludearch == "alpha"
+        assert spec.exclusivearch == "i386 x86_64"
 
     def test_parse_llvm_spec(self) -> None:
         spec = Spec.from_file(os.path.join(CURRENT_DIR, "llvm.spec"))

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -37,6 +37,9 @@ class TestSpecFileParser:
         assert spec.buildarch == "noarch"
         assert spec.excludearch == "alpha"
         assert spec.exclusivearch == "i386 x86_64"
+        assert spec.buildarch_list == ["noarch"]
+        assert spec.excludearch_list == ["alpha"]
+        assert spec.exclusivearch_list == ["i386", "x86_64"]
 
     def test_parse_llvm_spec(self) -> None:
         spec = Spec.from_file(os.path.join(CURRENT_DIR, "llvm.spec"))


### PR DESCRIPTION
1. The ExcludeArch, ExclusiveArch tag can be support.
2. As the `excludearch`  is a string of multi arches joined by blank, split the tag to a list at the same time;

@bkircher 