### PR TITLE
fix parse error in build_requires if comments behind

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -181,6 +181,8 @@ class _List(_Tag):
             "obsoletes",
             "provides",
         ]:
+            # fix parse error in build_requires if comments behind
+            value = value.split('#',2)[0].rstrip()
             # Macros are valid in requirements
             value = replace_macros(value, spec=spec_obj)
 


### PR DESCRIPTION
test src.rpm:

https://mirrors.tuna.tsinghua.edu.cn/centos-vault/7.6.1810/cloud/Source/openstack-pike/common/python-autobahn-0.10.9-1.gitcf10233.el7.src.rpm


=================
before fix:
>>> s.build_requires
[python2-devel, python-pep8, python-flake8, python-mock >= 1.0.1, pytest >= 2.6.4, python-six, python2-txaio, python-trollius, python-unittest2, python-scour, #, No, python, 3, https://github.com/oberstet/scour/issues/4, scons, python-taschenmesser, #, No, python, 3, https://github.com/oberstet/taschenmesser/issues/3, python-sphinx, python-sphinx-theme-bootstrap, #, Not, packaged, yet, python-sphinxcontrib-spelling, #, Not, packaged, yet, python-repoze-sphinx-autointerface, python-pyenchant]

==================
after fix:

>>> s.build_requires
[python2-devel, python-pep8, python-flake8, python-mock >= 1.0.1, pytest >= 2.6.4, python-six, python2-txaio, python-trollius, python-unittest2, python-scour, scons, python-taschenmesser, python-sphinx, python-sphinx-theme-bootstrap, python-sphinxcontrib-spelling, python-repoze-sphinx-autointerface, python-pyenchant]


