### PR TITLE
spec: make Spec factory functions as classmethods

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -450,30 +450,30 @@ class Spec:
         assert self.packages
         return dict(zip([package.name for package in self.packages], self.packages))
 
-    @staticmethod
-    def from_file(filename: str) -> "Spec":
+    @classmethod
+    def from_file(cls, filename: str) -> "Spec":
         """Creates a new Spec object from a given file.
 
         :param filename: The path to the spec file.
         :return: A new Spec object.
         """
 
-        spec = Spec()
+        spec = cls()
         with open(filename, "r", encoding="utf-8") as f:
             parse_context = {"current_subpackage": None}
             for line in f:
                 spec, parse_context = _parse(spec, parse_context, line.rstrip())
         return spec
 
-    @staticmethod
-    def from_string(string: str) -> "Spec":
+    @classmethod
+    def from_string(cls, string: str) -> "Spec":
         """Creates a new Spec object from a given string.
 
         :param string: The contents of a spec file.
         :return: A new Spec object.
         """
 
-        spec = Spec()
+        spec = cls()
         parse_context = {"current_subpackage": None}
         for line in string.splitlines():
             spec, parse_context = _parse(spec, parse_context, line)


### PR DESCRIPTION
For extending Spec-generating methods should consider actual class.

Example:
```python

from pyrpm.spec import Spec

class MySpec(Spec):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.useful_info = {}

    # some useful methods
    ...

spec = MySpec.from_file("path/to/spec")  # returns Spec object instead of MySpec
print(spec.useful_info)  # raises AttributeError
```