### PR TITLE
Allow macro without braces

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -506,6 +506,7 @@ def replace_macros(string: str, spec: Spec) -> str:
     def _macro_repl(match):
         # pylint: disable=too-many-return-statements
         macro_name = match.group(1)
+        assert macro_name
         if _is_conditional(macro_name) and spec:
             parts = macro_name[1:].split(sep=":", maxsplit=1)
             assert parts

--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -280,7 +280,7 @@ _tags = [
 
 _tag_names = [tag.name for tag in _tags]
 
-_macro_pattern = re.compile(r"%{(\S+?)\}")
+_macro_pattern = re.compile(r"%{(\S+?)\}|%(\w+?)\b")
 
 
 def _parse(spec_obj: "Spec", context: Dict[str, Any], line: str) -> Any:
@@ -493,6 +493,12 @@ def replace_macros(string: str, spec: Spec) -> str:
     """
     assert isinstance(spec, Spec)
 
+    def _first_not_none(tup: Tuple[Any]) -> Any:
+        for i in tup:
+            if i is not None:
+                return i
+        raise AssertionError("All elements in tuple are None")
+
     def _is_conditional(macro: str) -> bool:
         return macro.startswith("?") or macro.startswith("!")
 
@@ -505,7 +511,8 @@ def replace_macros(string: str, spec: Spec) -> str:
 
     def _macro_repl(match):
         # pylint: disable=too-many-return-statements
-        macro_name = match.group(1)
+        groups = match.groups()
+        macro_name = _first_not_none(groups)
         assert macro_name
         if _is_conditional(macro_name) and spec:
             parts = macro_name[1:].split(sep=":", maxsplit=1)

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -324,6 +324,14 @@ Version:        2
         s = "%{name}/%{version}/%{var}"
         assert replace_macros(s, spec) == "foo/2/bar"
 
+    def test_replace_macro_without_braces(self) -> None:
+        spec = Spec.from_string(
+            """
+%define var bar
+"""
+        )
+        assert replace_macros("foo-%var", spec) == "foo-bar"
+
     def test_replace_macro_with_negative_conditional(self) -> None:
         spec = Spec.from_file(os.path.join(CURRENT_DIR, "git.spec"))
 


### PR DESCRIPTION
Make replace_macros work even if macros without curly braces are used.