### PR TITLE
Parse %package line properly.

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -152,7 +152,7 @@ class _List(_Tag):
         value = match_obj.group(1)
         if self.name == "packages":
             if value == "-n":
-                subpackage_name = line.rsplit(" ", 1)[-1].rstrip()
+                subpackage_name = re.split(r'\s+', line)[-1].rstrip()
             else:
                 subpackage_name = f"{spec_obj.name}-{value}"
             package = Package(subpackage_name)


### PR DESCRIPTION
Use the same regex pattern to cut out a line.

Fixes https://github.com/bkircher/python-rpm-spec/issues/57