### PR TITLE
Fix replacement of conditional user-defined macros

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -519,11 +519,17 @@ def replace_macros(string: str, spec: Spec) -> str:
             parts = macro_name[1:].split(sep=":", maxsplit=1)
             assert parts
             if _test_conditional(macro_name):
-                if hasattr(spec, parts[0]) or parts[0] in spec.macros:
+                if parts[0] in spec.macros or hasattr(spec, parts[0]):
                     if len(parts) == 2:
                         return parts[1]
 
-                    return spec.macros.get(parts[0], getattr(spec, parts[0]))
+                    if parts[0] in spec.macros:
+                        return spec.macros[parts[0]]
+
+                    if hasattr(spec, parts[0]):
+                        return getattr(spec, parts[0])
+
+                    assert False, "Unreachable"
 
                 return ""
 

--- a/tests/test_spec_file_parser.py
+++ b/tests/test_spec_file_parser.py
@@ -185,6 +185,19 @@ Version: %{version}
         )
         assert replace_macros(spec.version, spec) == "1.2.3"
 
+    def test_custom_conditional_macro(self) -> None:
+        """Test that a user-defined conditional macro is being replaced.
+        """
+        spec = Spec.from_string(
+            r"""
+Name: foo
+Version: 1
+Release: 1%{?dist}
+        """
+        )
+        spec.macros['dist'] = '.el8'
+        assert replace_macros(f"{spec.name}-{spec.version}-{spec.release}.src.rpm", spec) == "foo-1-1.el8.src.rpm"
+
     def test_requirement_parsing(self) -> None:
         spec = Spec.from_file(os.path.join(CURRENT_DIR, "attica-qt5.spec"))
 


### PR DESCRIPTION
Users can define custom macros by setting
`spec.macros['my_macro'] = 'my_value'`. This worked fine up to the 0.14 release, where commit 37e129bef531630de0ac7c8e952d2b40b817f22c broke this behavior in what seems like an unintended side effect from a refactoring:

```
  File "pyrpm/spec.py", line 548, in replace_macros
    ret = re.sub(_macro_pattern, _macro_repl, string)
  File "/usr/lib64/python3.9/re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "pyrpm/spec.py", line 526, in _macro_repl
    return spec.macros.get(parts[0], getattr(spec, parts[0]))
AttributeError: 'Spec' object has no attribute 'dist'
```

Bring the old behavior back, and add a test for it.