### PR TITLE
Use flit_core as build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 dist-name = "python-rpm-spec"


### PR DESCRIPTION
And specify a version range. This should make building faster, and ensure it works with Flit 3.x regardless of changes in future versions.

For example, we're moving from the Flit-specific `[tool.flit.metadata]` table to the standardised `[project]` table, and the plan for Flit 4 is to only support the latter. [pyprpoject.toml docs](https://flit.pypa.io/en/stable/pyproject_toml.html)