### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
 
       - name: Publish to PyPI using flit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
 
       - name: Test build wheel package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # We try to go with the currently active Python branches:
         # https://devguide.python.org/versions/#versions
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.black-formatter",
+        "ms-python.pylint",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,15 @@
 {
-    "python.formatting.provider": "black",
-    "python.formatting.blackArgs": [
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.rulers": [
+            130
+        ],
+    },
+    "black-formatter.args": [
         "--line-length",
         "130",
         "--target-version",
         "py312"
-    ],
-    "editor.rulers": [
-        130
     ],
     "python.testing.pytestArgs": [
         "tests",
@@ -16,5 +18,4 @@
     "python.testing.pytestEnabled": true,
     "python.testing.autoTestDiscoverOnSaveEnabled": true,
     "editor.formatOnSaveMode": "modifications",
-    "python.linting.pylintEnabled": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "--line-length",
         "130",
         "--target-version",
-        "py311"
+        "py312"
     ],
     "editor.rulers": [
         130

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All [current Python branches](https://devguide.python.org/versions/#versions) ar
 
 | Python Version | Supported Until |
 | :------------- | --------------: |
+| 3.12           | 2028-10         |
 | 3.11           | 2027-10         |
 | 3.10           | 2026-10         |
 | 3.9            | 2025-10         |

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@ show_traceback = True
 # Display the codes needed for # type: ignore[code] annotations.
 show_error_codes = True
 
-python_version = 3.11
+python_version = 3.12
 
 # Stricter type checking.
 disallow_untyped_calls = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,7 @@ author-email = "bkircher@0xadd.de"
 home-page = "https://github.com/bkircher/python-rpm-spec"
 requires-python = ">=3.8"
 description-file = "README.md"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 130

--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -172,7 +172,7 @@ class _List(_Tag):
             #   Requires: a, b >= 3.1, c
 
             # 1. Tokenize
-            tokens = [val for val in re.split("[\t\n, ]", value) if val != ""]
+            tokens = [val for val in re.split("[\t\n, ]", value) if val]
             values: List[str] = []
 
             # 2. Join

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-black==23.1.0
-coverage==7.2.1
-flit==3.8.0
-mypy==1.0.1
-pylint==2.16.3
-pytest-cov==4.0.0
+black==24.1.1
+coverage==7.4.1
+flit==3.9.0
+mypy==1.8.0
+pylint==3.0.3
+pytest-cov==4.1.0
 pytest-mypy==0.10.3
-pytest==7.2.2
-rope==1.7.0
+pytest==8.0.0
+rope==1.12.0


### PR DESCRIPTION
Add 3.12 to test matrix and update tooling and dependencies.

Changes:

- CI: add 3.12 to test matrix.
- Fix pylint warning.
- Add ruff to pyproject.toml and update .vscode/settings.json to use 3.12 for black.
- Update VS Code extension settings for Python 3.12 support.
- Bump everything to the latest version:
```raw
    black      23.1.0 → 24.1.1
    coverage   7.2.1  → 7.4.1
    flit       3.8.0  → 3.9.0
    mypy       1.0.1  → 1.8.0
    pylint     2.16.3 → 3.0.3
    pytest     7.2.2  → 8.0.0
    pytest-cov 4.0.0  → 4.1.0
    rope       1.7.0  → 1.12.0
```