### PR TITLE
Fix endless loop

### DIFF
--- a/pyrpm/spec.py
+++ b/pyrpm/spec.py
@@ -163,8 +163,6 @@ class _List(_Tag):
         ]:
             # Remove comments on same line
             value = value.split("#", 2)[0].rstrip()
-            # Macros are valid in requirements
-            value = replace_macros(value, spec=spec_obj)
 
             # It's also legal to do:
             #   Requires: a b c

--- a/scripts/fedora_sources.py
+++ b/scripts/fedora_sources.py
@@ -4,15 +4,8 @@ import sys
 from pyrpm.spec import Spec
 
 
-# Spec files to skip because of known issues. All of the following end up in an
-# endless loop
-skipfiles = (
-    "cairo-dock.spec",
-    "ghc",
-    "libreoffice.spec",
-    "python-pyghmi.spec",
-    "xscreensaver.spec",
-)
+# Spec files to skip because of known issues.
+skipfiles = ()
 
 
 def skip(filename: str) -> bool:


### PR DESCRIPTION
Fix possible endless loop when parsing

- build_requires
- requires
- conflicts
- obsoletes
- provides

tags that contain macros.

Fixes #66.